### PR TITLE
Build with stock devkitadv r4

### DIFF
--- a/lnkscript
+++ b/lnkscript
@@ -61,6 +61,7 @@ SECTIONS
 
   .eh_frame :
   {
+    __EH_FRAME_BEGIN__ = .;
     KEEP (*(.eh_frame))
     . = ALIGN(4);
   } = 0

--- a/make.bat
+++ b/make.bat
@@ -31,7 +31,7 @@ gcc -c -O2 -mthumb -mthumb-interwork    -o saverestore.o saverestore.c
 gcc -c -O3 -mthumb -mthumb-interwork    -o interrupts.o interrupts.c
 
 
-gcc -Wl,-Tlnkscript  -mthumb -mthumb-interwork  -o test.elf main.o interrupts.o agimain.o gamedata.o input.o keyboard.o invobj.o logic.o picture.o screen.o status.o variables.o views.o system.o commands.o cmdagi.o cmdtest.o errmsg.o text.o menu.o parse.o saverestore.o wingui.o
+gcc -nostartfiles -Wl,-Tlnkscript  -mthumb -mthumb-interwork  -o test.elf crt0.o main.o interrupts.o agimain.o gamedata.o input.o keyboard.o invobj.o logic.o picture.o screen.o status.o variables.o views.o system.o commands.o cmdagi.o cmdtest.o errmsg.o text.o menu.o parse.o saverestore.o wingui.o
 objcopy -O binary test.elf gbagi.bin
 cd gbarom
 .\aginject


### PR DESCRIPTION
crt0.s/.o in the repo isn't included when linking, so the interrupts crash during the splash screen. 

building with plain devkitadv r4 from sourceforge and cygwin binaries from http://ctm.crouchingtigerhiddenfruitbat.org/pub/cygwin/release/cygwin/cygwin-1.3.10-1.tar.bz2 and http://ctm.crouchingtigerhiddenfruitbat.org/pub/cygwin/release/gettext/libintl/libintl-0.10.38-3.tar.bz2
